### PR TITLE
Deploy to VPS with k3s infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,85 @@
+name: Deploy to k3s
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: sakuraore/oshidoko:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: "v1.28.0"
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Deploy to k3s
+        run: |
+          # Apply Kubernetes manifests
+          kubectl apply -f k8s/namespace.yaml
+          kubectl apply -f k8s/configmap.yaml
+          kubectl apply -f k8s/secret.yaml
+          kubectl apply -f k8s/mysql-deployment.yaml
+          kubectl apply -f k8s/minio-deployment.yaml
+          kubectl apply -f k8s/minio-ingress.yaml
+
+          # Wait for dependencies
+          kubectl wait --for=condition=ready pod -l app=mysql -n oshidoko --timeout=300s
+          kubectl wait --for=condition=ready pod -l app=minio -n oshidoko --timeout=300s
+
+          # Deploy Rails application
+          kubectl apply -f k8s/rails-deployment.yaml
+          kubectl apply -f k8s/ingress.yaml
+
+          # Wait for Rails pods
+          kubectl wait --for=condition=ready pod -l app=oshidoko-web -n oshidoko --timeout=300s
+
+      - name: Initialize MinIO (if needed)
+        run: |
+          # Check if MinIO user already exists
+          if ! kubectl exec -n oshidoko deployment/minio -- mc admin user list local | grep -q "minio_oshidokoak"; then
+            kubectl exec -n oshidoko deployment/minio -- mc alias set local http://localhost:9000 admin adminpassword
+            kubectl exec -n oshidoko deployment/minio -- mc admin user add local minio_oshidokoak minio_oshidokosk
+            kubectl exec -n oshidoko deployment/minio -- mc admin policy attach local readwrite --user minio_oshidokoak
+            kubectl exec -n oshidoko deployment/minio -- mc mb local/oshidoko-bucket --ignore-existing
+            kubectl exec -n oshidoko deployment/minio -- mc anonymous set public local/oshidoko-bucket
+          fi
+
+      - name: Deployment Status
+        run: |
+          echo "Deployment completed successfully!"
+          kubectl get pods -n oshidoko
+          kubectl get ingress -n oshidoko

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn-debug.log*
 .env
 
 .vscode
+
+k8s/secret.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@
 yarn-debug.log*
 .yarn-integrity
 .env
+
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.7.5
 
 ENV RAILS_ENV=production
+ENV BUNDLE_WITHOUT=development:test
 
 # yarnをインストール
 RUN apt-get update && apt-get install -y curl apt-transport-https wget && \
@@ -26,6 +27,9 @@ RUN bundle install
 
 # ローカルのmyapp配下のファイルをコンテナ内のmyapp配下にコピー
 COPY . /myapp
+
+# アセットをプリコンパイル（ビルド時に実行）
+RUN RAILS_ENV=production bundle exec rails assets:precompile
 
 # コンテナ起動時に実行させるスクリプトを追加
 COPY entrypoint.sh /usr/bin/

--- a/GITHUB_SECRETS_SETUP.md
+++ b/GITHUB_SECRETS_SETUP.md
@@ -1,0 +1,35 @@
+# GitHub Secrets 設定ガイド
+
+GitHub Actions で CI/CD を動作させるために、以下の Secrets をリポジトリに設定してください。
+
+## 設定方法
+
+1. GitHub リポジトリ → Settings → Secrets and variables → Actions
+2. "New repository secret"をクリック
+3. 以下の Secrets を追加
+
+## 必要な Secrets
+
+### DOCKER_USERNAME
+
+- Docker Hub のユーザー名
+
+### DOCKER_PASSWORD
+
+- Docker Hub の Personal Access Token
+- Docker Hub → Account Settings → Security → New Access Token
+
+### KUBECONFIG
+
+- k3s クラスターの kubeconfig ファイル（Base64 エンコード済み）
+- VPS で以下のコマンドを実行して Base64 エンコード:
+
+```bash
+sudo cat /etc/rancher/k3s/k3s.yaml | base64 -w 0
+```
+
+- 出力された文字列を Secrets に設定
+
+## 設定確認
+
+すべての Secrets が設定されたら、`main`ブランチに push して GitHub Actions が正常に動作することを確認してください。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OSHIDOKO
-日向坂46の「聖地」と呼ばれる場所を共有するサービスです。
+
+日向坂 46 の「聖地」と呼ばれる場所を共有するサービスです。
+
 - **聖地の共有**
   - 聖地の場所を写真やコメント等とともに投稿することができます。投稿した聖地はオリジナルの地図で共有されます。
 - **聖地の探索**
@@ -10,9 +12,12 @@
 ![マップ1](./images_for_README/map_1.png)
 
 ## URL
-* https://oshidoko-d1f4be94096c.herokuapp.com/
+
+- https://oshidoko.reokambara.com/
+- ~~https://oshidoko-d1f4be94096c.herokuapp.com/~~(Heroku 運用停止中)
 
 ## 使い方
+
 **＜新規登録・ログイン＞**<br>
 投稿の閲覧のみログインなしで可能です。全ての機能をご利用の場合は、アカウントを登録してログインしてください。<br>
 (ログイン画面にあるゲストログインを押すと、ゲストユーザーとしてアカウント登録なしでログインできます。)
@@ -42,7 +47,8 @@
 聖地の投稿は、トップページ右下の投稿ボタンより作成できます。
 
 ## 開発背景
-日向坂46には、MVや写真集・雑誌・出演TV番組の撮影地をはじめ、メンバーがブログやメッセージアプリで紹介した数多くの聖地があります。
+
+日向坂 46 には、MV や写真集・雑誌・出演 TV 番組の撮影地をはじめ、メンバーがブログやメッセージアプリで紹介した数多くの聖地があります。
 私は推し活としてその聖地に直接訪れることもありますが、ライブ遠征や旅行のついでに「もし近くに聖地があったらちょっと行ってみようかな?」くらいの気分でふらっと立ち寄ることが多いです。
 
 そのようなの時に聖地を調べるのですが、うまく見つけられなかったり、欲しい情報が散らばっていたりして、探すのになかなか手間取ったりしたことがあります。
@@ -53,6 +59,7 @@
 「OSHIDOKO」はファンの推し活をより充実させることを目的としていますが、同時にその聖地巡礼という形の推し活が、聖地となっている地域（特に地方）の活性化にも少しでも貢献できればとも考えています。
 
 ## こだわりポイント
+
 聖地を投稿する際、その聖地に関連するメンバーを紐づけて投稿できるようにしました。
 
 投稿された聖地にどのメンバーが関係しているのかを確認できるため、グループの聖地としてだけでなくメンバー単位で聖地を知ることができます。
@@ -62,46 +69,104 @@
 サービス名の「OSHIDOKO」という名からも想像できるように、自分の推しメンがどこを訪れたのかを簡単に確認できる、推しメンを追いやすい作りに仕上げました。
 
 # 使用技術
-* Ruby 2.7.5
-* Ruby on Rails 6.1.7.3
-* MySQL 8.0.33
-* Docker
-* CircleCI
-* RSpec
-* Google Maps API
-* Heroku
 
-# システム構成図
-![システム構成図](./images_for_README/system_composition.png)
-## CircleCIの流れ
-1. Githubのリモートリポジトリにpushすると，RSpecとRuboCopによる静的コード解析がCircleCI上で自動実行される
-2. RSpec/Rubocopともに問題がない場合，最新のコードがHeroku上にデプロイされる
+- Ruby 2.7.5
+- Ruby on Rails 6.1.7.3
+- MySQL 8.0.33
+- Docker
+- Kubernetes (k3s)
+- MinIO (S3 互換オブジェクトストレージ)
+- GitHub Actions
+- RSpec
+- Google Maps API
+- ~~AWS S3~~ (MinIO に移行)
+- ~~CircleCI~~ (GitHub Actions に移行)
+- ~~Heroku~~ (VPS + k3s に移行)
+
+# インフラ構成
+
+## 現在の構成 (VPS + k3s)
+
+```
+Internet → Traefik Ingress → k3s Cluster
+                           ├── Rails App (Pod)
+                           ├── MySQL (Pod)
+                           └── MinIO (Pod)
+```
+
+### 主要コンポーネント
+
+- **VPS**: Xserver VPS (Ubuntu)
+- **Container Orchestration**: k3s (軽量 Kubernetes)
+- **Ingress Controller**: Traefik (k3s 標準)
+- **SSL/TLS**: Let's Encrypt (cert-manager)
+- **Object Storage**: MinIO (S3 互換)
+- **Database**: MySQL 8.0
+- **CI/CD**: GitHub Actions
+
+### ドメイン構成
+
+- **メインアプリ**: https://oshidoko.reokambara.com
+- **MinIO API**: https://minio.oshidoko.reokambara.com
+
+## 旧構成 (Heroku)
+
+~~![システム構成図](./images_for_README/system_composition.png)~~
+
+### CircleCI の流れ
+
+1. Github のリモートリポジトリに push すると，RSpec と RuboCop による静的コード解析が CircleCI 上で自動実行される
+2. RSpec/Rubocop ともに問題がない場合，最新のコードが Heroku 上にデプロイされる
+
+## GitHub Actions の流れ
+
+1. `main`ブランチへの push または PR マージ時に自動実行
+2. Docker イメージをビルド・プッシュ
+3. k3s クラスターに Kubernetes マニフェストを適用
+4. アプリケーションの自動デプロイ完了
+
+## デプロイ方法
+
+### 手動デプロイ
+
+```bash
+./deploy.sh
+```
+
+### 自動デプロイ
+
+- `main`ブランチに push または PR マージで自動実行
+- GitHub Actions の設定: `.github/workflows/deploy.yml`
+- 必要な Secrets 設定: [GITHUB_SECRETS_SETUP.md](./GITHUB_SECRETS_SETUP.md)
 
 # 機能一覧
-* ユーザー登録機能，ログイン機能(devise)
-  * アカウント認証
-  * パスワード再設定
-  * アカウント編集
-  * プロフィール追加
-  * 退会
-  * ゲストログイン
-* 投稿機能
-  * 住所検索
-  * 画像アップロード
-* 投稿表示機能
-  * マップ表示
-  * 一覧表示
-    * 投稿検索
-    * ページネーション(kaminari)
-* 投稿いいね機能(Ajax)
-* 投稿レビュー機能(Ajax)
-* ユーザーフォロー機能(Ajax)
-* お問い合わせ機能
 
-## ER図
+- ユーザー登録機能，ログイン機能(devise)
+  - アカウント認証
+  - パスワード再設定
+  - アカウント編集
+  - プロフィール追加
+  - 退会
+  - ゲストログイン
+- 投稿機能
+  - 住所検索
+  - 画像アップロード
+- 投稿表示機能
+  - マップ表示
+  - 一覧表示
+    - 投稿検索
+    - ページネーション(kaminari)
+- 投稿いいね機能(Ajax)
+- 投稿レビュー機能(Ajax)
+- ユーザーフォロー機能(Ajax)
+- お問い合わせ機能
+
+## ER 図
+
 ![ER図](./images_for_README/oshidoko_erd.png)
 
 # テスト
-* RSpec
-  * 単体テスト(Model Spec)
-  * 統合テスト(System Spec)
+
+- RSpec
+  - 単体テスト(Model Spec)
+  - 統合テスト(System Spec)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,10 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :minio
+
+  # MinIO用の設定
+  config.active_storage.variant_processor = :mini_magick
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,10 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :minio
+  config.active_storage.service = :minio_production
+
+  # MinIO用の設定
+  config.active_storage.variant_processor = :mini_magick
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :minio
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
@@ -119,7 +119,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # メール送信用の設定
-  config.action_mailer.default_url_options = { host: 'https://oshidoko-d1f4be94096c.herokuapp.com/'}
+  config.action_mailer.default_url_options = { host: ENV['APP_HOST'] || 'localhost' }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,13 +7,22 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-amazon:
-  service: S3
-  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  region: <%= ENV['AWS_REGION'] %>
-  bucket: <%= ENV['AWS_BUCKET'] %>
+# amazon:
+#   service: S3
+#   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+#   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+#   region: <%= ENV['AWS_REGION'] %>
+#   bucket: <%= ENV['AWS_BUCKET'] %>
 
+minio:
+  service: S3
+  access_key_id: <%= ENV['MINIO_ACCESS_KEY'] %>
+  secret_access_key: <%= ENV['MINIO_SECRET_KEY'] %>
+  region: "us-east-1"
+  bucket: <%= ENV['MINIO_BUCKET'] %>
+  endpoint: <%= ENV['MINIO_ENDPOINT'] %>
+  force_path_style: true
+  public: true
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -23,6 +23,18 @@ minio:
   endpoint: <%= ENV['MINIO_ENDPOINT'] %>
   force_path_style: true
   public: true
+
+# 本番環境用MinIO設定（外部URL使用）
+minio_production:
+  service: S3
+  access_key_id: <%= ENV['MINIO_ACCESS_KEY'] %>
+  secret_access_key: <%= ENV['MINIO_SECRET_KEY'] %>
+  region: "us-east-1"
+  bucket: <%= ENV['MINIO_BUCKET'] %>
+  endpoint: <%= ENV['MINIO_PUBLIC_ENDPOINT'] %>
+  force_path_style: true
+  public: true
+
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# k3sデプロイスクリプト
+set -e  # エラー時に停止
+
+echo "Starting deployment to k3s..."
+
+# Docker buildxが利用可能か確認
+if ! docker buildx version > /dev/null 2>&1; then
+  echo "Docker buildx is not available. Please install Docker Desktop or enable buildx."
+  exit 1
+fi
+
+# Docker イメージを x86_64 向けにビルドして Docker Hub に直接 push
+echo "Building and pushing Docker image for x86_64 architecture..."
+docker buildx build --platform linux/amd64 -t sakuraore/oshidoko:latest . --push
+# --platform linux/amd64 : k3s(VPS) で動作するアーキテクチャを指定
+# -t sakuraore/oshidoko:latest : Docker Hub 上のリポジトリ名とタグ
+# --push : ビルド後に自動で Docker Hub にアップロード
+
+echo "Image built and pushed successfully!"
+
+# Kubernetes マニフェストを適用
+echo "Applying Kubernetes manifests..."
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/configmap.yaml
+kubectl apply -f k8s/secret.yaml
+
+# データベース(MySQL) とストレージ(MinIO) を先にデプロイ
+echo "Deploying database and storage..."
+kubectl apply -f k8s/mysql-deployment.yaml
+kubectl apply -f k8s/minio-deployment.yaml
+
+# MySQL Pod が Ready になるまで待機
+echo "Waiting for database to be ready..."
+if kubectl wait --for=condition=ready pod -l app=mysql -n oshidoko --timeout=300s; then
+    echo "Database is ready!"
+else
+    echo "Database failed to start. Check logs with: kubectl logs -l app=mysql -n oshidoko"
+    exit 1
+fi
+
+# MinIO Pod が Ready になるまで待機
+echo "Waiting for MinIO to be ready..."
+if kubectl wait --for=condition=ready pod -l app=minio -n oshidoko --timeout=300s; then
+    echo "MinIO is ready!"
+else
+    echo "MinIO failed to start. Check logs with: kubectl logs -l app=minio -n oshidoko"
+    exit 1
+fi
+
+# Rails アプリケーションをデプロイ
+echo "Deploying Rails application..."
+kubectl apply -f k8s/rails-deployment.yaml
+kubectl apply -f k8s/ingress.yaml
+
+# Rails Pod が Ready になるまで待機
+echo "Waiting for Rails pods to be ready..."
+if kubectl wait --for=condition=ready pod -l app=oshidoko-web -n oshidoko --timeout=300s; then
+    echo "Rails application is ready!"
+else
+    echo "Rails application failed to start. Check logs with: kubectl logs -l app=oshidoko-web -n oshidoko"
+    exit 1
+fi
+
+# デプロイ完了の通知と確認用メッセージ
+echo ""
+echo "Deployment completed successfully!"
+echo ""
+echo "Status check:"
+kubectl get pods -n oshidoko
+echo ""
+echo "Next steps:"
+# バケット作成や初期ユーザー設定
+echo "1. Initialize MinIO: ./scripts/init-minio.sh"
+# Ingress のアドレス確認
+echo "2. Check application: kubectl get ingress -n oshidoko"
+# Rails ログ確認
+echo "3. View logs: kubectl logs -l app=oshidoko-web -n oshidoko"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: mysql:latest
     platform: linux/amd64
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
     ports:
       - "3306:3306"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-version: '3'
+version: "3"
+
 services:
   db:
     container_name: oshidoko_db
@@ -26,3 +27,17 @@ services:
     image: seleniarm/standalone-chromium
     ports:
       - 4444:4444
+  minio:
+    image: minio/minio:latest
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    ports:
+      - "9000:9000" # API
+      - "9001:9001" # Web コンソール
+    volumes:
+      - minio_data:/data
+
+volumes:
+  minio_data:

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,90 @@
+# k3s デプロイメントガイド
+
+## 前提条件
+
+- k3s クラスターが稼働していること
+- kubectl が k3s クラスターに接続できること
+- Docker レジストリへのアクセス権限があること
+
+## デプロイ手順
+
+### 1. 設定の更新
+
+以下のファイルを実際の環境に合わせて更新してください：
+
+- `k8s/configmap.yaml`: `APP_HOST`を実際のドメインに変更
+- `k8s/secret.yaml`: パスワードやキーを実際の値に変更
+- `k8s/rails-deployment.yaml`: Docker イメージを実際のレジストリのものに変更
+- `k8s/ingress.yaml`: ドメイン名を実際のものに変更
+
+### 2. Docker イメージのビルドとプッシュ
+
+```bash
+# イメージをビルド
+docker build -t your-registry/oshidoko:latest .
+
+# レジストリにプッシュ
+docker push your-registry/oshidoko:latest
+```
+
+### 3. デプロイの実行
+
+```bash
+# 自動デプロイスクリプトを実行
+./deploy.sh
+
+# または手動でデプロイ
+kubectl apply -f k8s/
+```
+
+### 4. MinIO の初期化
+
+```bash
+# MinIOの設定を実行
+./scripts/init-minio.sh
+```
+
+### 5. 動作確認
+
+```bash
+# ポッドの状態確認
+kubectl get pods -n oshidoko
+
+# サービスの確認
+kubectl get services -n oshidoko
+
+# Ingressの確認
+kubectl get ingress -n oshidoko
+```
+
+## トラブルシューティング
+
+### ログの確認
+
+```bash
+# Railsアプリのログ
+kubectl logs -n oshidoko -l app=oshidoko-web
+
+# MySQLのログ
+kubectl logs -n oshidoko -l app=mysql
+
+# MinIOのログ
+kubectl logs -n oshidoko -l app=minio
+```
+
+### データベースの初期化
+
+```bash
+# マイグレーションの実行
+kubectl exec -n oshidoko deployment/oshidoko-web -- bundle exec rails db:migrate
+
+# シードデータの投入
+kubectl exec -n oshidoko deployment/oshidoko-web -- bundle exec rails db:seed
+```
+
+## 重要な注意事項
+
+1. **セキュリティ**: `k8s/secret.yaml`の値は実際の本番環境用の安全な値に変更してください
+2. **ドメイン**: 実際のドメイン名に変更してください
+3. **SSL 証明書**: cert-manager を使用して SSL 証明書を自動取得することを推奨します
+4. **バックアップ**: データベースと MinIO のデータは定期的にバックアップしてください

--- a/k8s/cluster-issuer.yaml
+++ b/k8s/cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: reo.k.dev@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: traefik

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oshidoko-config
+  namespace: oshidoko
+data:
+  RAILS_ENV: "production"
+  RAILS_SERVE_STATIC_FILES: "true"
+  RAILS_LOG_TO_STDOUT: "true"
+  MINIO_BUCKET: "oshidoko-bucket"
+  MINIO_ENDPOINT: "http://minio-service:9000"
+  APP_HOST: "oshidoko.reokambara.com"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -9,4 +9,5 @@ data:
   RAILS_LOG_TO_STDOUT: "true"
   MINIO_BUCKET: "oshidoko-bucket"
   MINIO_ENDPOINT: "http://minio-service:9000"
+  MINIO_PUBLIC_ENDPOINT: "https://minio.oshidoko.reokambara.com"
   APP_HOST: "oshidoko.reokambara.com"

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oshidoko-ingress
+  namespace: oshidoko
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - oshidoko.reokambara.com
+      secretName: oshidoko-tls
+  rules:
+    - host: oshidoko.reokambara.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: oshidoko-web-service
+                port:
+                  number: 80

--- a/k8s/minio-deployment.yaml
+++ b/k8s/minio-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: oshidoko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - minio server /data --console-address :9001
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: oshidoko-config
+                  key: MINIO_ROOT_USER
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oshidoko-secret
+                  key: MINIO_ROOT_PASSWORD
+          ports:
+            - containerPort: 9000
+            - containerPort: 9001
+          volumeMounts:
+            - name: minio-storage
+              mountPath: /data
+      volumes:
+        - name: minio-storage
+          persistentVolumeClaim:
+            claimName: minio-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-service
+  namespace: oshidoko
+spec:
+  selector:
+    app: minio
+  ports:
+    - name: api
+      port: 9000
+      targetPort: 9000
+    - name: console
+      port: 9001
+      targetPort: 9001
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-pvc
+  namespace: oshidoko
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/k8s/minio-ingress.yaml
+++ b/k8s/minio-ingress.yaml
@@ -1,0 +1,26 @@
+# MinIO API用Ingress（画像表示用）
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-api-ingress
+  namespace: oshidoko
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - minio.oshidoko.reokambara.com
+      secretName: minio-api-tls
+  rules:
+    - host: minio.oshidoko.reokambara.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio-service
+                port:
+                  number: 9000

--- a/k8s/mysql-deployment.yaml
+++ b/k8s/mysql-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  namespace: oshidoko
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:8.0
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oshidoko-secret
+                  key: MYAPP_DATABASE_PASSWORD
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: oshidoko-secret
+                  key: MYAPP_DATABASE
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: oshidoko-secret
+                  key: MYAPP_DATABASE_USERNAME
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: oshidoko-secret
+                  key: MYAPP_DATABASE_PASSWORD
+          ports:
+            - containerPort: 3306
+          volumeMounts:
+            - name: mysql-storage
+              mountPath: /var/lib/mysql
+          args:
+            - --default-authentication-plugin=mysql_native_password
+      volumes:
+        - name: mysql-storage
+          persistentVolumeClaim:
+            claimName: mysql-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  namespace: oshidoko
+spec:
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+  namespace: oshidoko
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oshidoko

--- a/k8s/rails-deployment.yaml
+++ b/k8s/rails-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oshidoko-web
+  namespace: oshidoko
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: oshidoko-web
+  template:
+    metadata:
+      labels:
+        app: oshidoko-web
+    spec:
+      imagePullSecrets:
+        - name: regcred
+      initContainers:
+        - name: db-migrate
+          image: sakuraore/oshidoko:latest
+          command: ["bundle", "exec", "rails", "db:migrate"]
+          envFrom:
+            - configMapRef:
+                name: oshidoko-config
+            - secretRef:
+                name: oshidoko-secret
+      containers:
+        - name: web
+          image: sakuraore/oshidoko:latest
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: oshidoko-config
+            - secretRef:
+                name: oshidoko-secret
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oshidoko-web-service
+  namespace: oshidoko
+spec:
+  selector:
+    app: oshidoko-web
+  ports:
+    - port: 80
+      targetPort: 3000
+  type: ClusterIP

--- a/scripts/init-minio.sh
+++ b/scripts/init-minio.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# MinIO初期化スクリプト
+# k3sデプロイ後に実行してください
+
+echo "Setting up MinIO..."
+
+# MinIOポッドの名前を取得
+MINIO_POD=$(kubectl get pods -n oshidoko -l app=minio -o jsonpath='{.items[0].metadata.name}')
+
+echo "MinIO pod: $MINIO_POD"
+
+# MinIO Clientの設定
+kubectl exec -n oshidoko $MINIO_POD -- mc alias set local http://localhost:9000 admin adminpassword
+
+# アプリケーション用ユーザーの作成
+kubectl exec -n oshidoko $MINIO_POD -- mc admin user add local minio_oshidokoak minio_oshidokosk
+
+# ポリシーの適用
+kubectl exec -n oshidoko $MINIO_POD -- mc admin policy attach local readwrite --user minio_oshidokoak
+
+# バケットの作成
+kubectl exec -n oshidoko $MINIO_POD -- mc mb local/oshidoko-bucket
+
+# バケットを公開読み取り可能に設定
+kubectl exec -n oshidoko $MINIO_POD -- mc anonymous set public local/oshidoko-bucket
+
+echo "MinIO setup completed!"

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
 
-if [ "${RAILS_ENV}" = "production" ]
-then
-    bundle exec rails assets:precompile
-fi
-
+# アセットプリコンパイルはDockerビルド時に完了済み
 bundle exec rails s -p ${PORT:-3000} -b 0.0.0.0


### PR DESCRIPTION
## 概要
Heroku から VPS + k3s への移行を実施。

## 主な変更内容

### インフラ構成の変更
- **Heroku -> VPS + k3s**: 軽量Kubernetesクラスターでの運用に移行
- **AWS S3 -> MinIO**: S3互換のオープンソースオブジェクトストレージに変更
- **CircleCI -> GitHub Actions**: CI/CDパイプラインをGitHub Actionsに移行

### 追加ファイル
- `k8s/`: Kubernetesマニフェストファイル一式
  - namespace
  - configmap
  - secret
  - deployments
  - services
  - ingress
- `.github/workflows/deploy.yml`: GitHub Actions CI/CDワークフロー
- `deploy.sh`: 手動デプロイ用スクリプト
- `scripts/init-minio.sh`: MinIO初期化スクリプト
- `GITHUB_SECRETS_SETUP.md`: GitHub Secrets設定ガイド

### 設定変更
- `config/storage.yml`: MinIO用設定を追加
- `config/environments/production.rb`: 本番環境でMinIOを使用
- `Dockerfile`: アセットプリコンパイルをビルド時に実行
- `README.md`: 新しいインフラ構成を文書化

### セキュリティ改善
- MinIO Webコンソールは外部非公開
- 最小限のポート開放（22, 80, 443, 6443のみ）
- Let's Encrypt自動SSL証明書

## デプロイ先
- **メインアプリ**: https://oshidoko.reokambara.com
- **MinIO API**: https://minio.oshidoko.reokambara.com

## 動作確認

- [x] アプリケーションの正常動作
- [x] 画像アップロード・表示機能
- [x] データベース移行完了
- [x] SSL証明書自動取得

## 備考

- Heroku環境は使用停止、新しいドメインで運用開始
- 要 GitHub Secrets の設定（DOCKER_USERNAME, DOCKER_PASSWORD, KUBECONFIG）